### PR TITLE
fix: permission handling issue in `finished`

### DIFF
--- a/finished/src/main/AndroidManifest.xml
+++ b/finished/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
       </intent-filter>
 
       <!-- TODO: Add intent filter to handle permission rationale intent -->
+      <!-- Permission handling for Android 13- -->
+      <intent-filter>
+        <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+      </intent-filter>
+
+      <!-- Permission handling for Android 14+ -->
       <intent-filter>
         <action android:name="android.intent.action.VIEW_PERMISSION_USAGE"/>
         <category android:name="android.intent.category.HEALTH_PERMISSIONS"/>


### PR DESCRIPTION
Add the intent filter in manifest file to fix the issue of `finished` not work for Android 13-