### PR TITLE
Add GitHub Actions workflows for building apps

### DIFF
--- a/.github/workflows/build-finished-app.yml
+++ b/.github/workflows/build-finished-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Health Connect Codelab - Finished App
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./android-health-connect-codelab
+
+      - name: Build finished app
+        working-directory: ./android-health-connect-codelab
+        run: ./gradlew :finished:assembleDebug

--- a/.github/workflows/build-start-app.yml
+++ b/.github/workflows/build-start-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Health Connect Codelab - Start App
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./android-health-connect-codelab
+
+      - name: Build start app
+        working-directory: ./android-health-connect-codelab
+        run: ./gradlew :start:assembleDebug


### PR DESCRIPTION
This commit adds two new GitHub Actions workflows to automate the build process for the Health Connect Codelab:

- `build-finished-app.yml`: Builds the "finished" version of the app.
- `build-start-app.yml`: Builds the "start" version of the app.

These workflows are triggered on push and pull requests to the `main` branch, as well as manually via `workflow_dispatch`. They set up Java and Gradle, make the Gradle wrapper executable, and then build the respective apps using the `assembleDebug` task.