### PR TITLE
Fix: Remove incorrect working-directory

### DIFF
--- a/.github/workflows/build-finished-app.yml
+++ b/.github/workflows/build-finished-app.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./android-health-connect-codelab
 
       - name: Build finished app
-        working-directory: ./android-health-connect-codelab
         run: ./gradlew :finished:assembleDebug

--- a/.github/workflows/build-start-app.yml
+++ b/.github/workflows/build-start-app.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./android-health-connect-codelab
 
       - name: Build start app
-        working-directory: ./android-health-connect-codelab
         run: ./gradlew :start:assembleDebug


### PR DESCRIPTION
This commit removes the incorrect `working-directory` from the GitHub Actions workflow files
`build-finished-app.yml` and `build-start-app.yml`. The gradlew command should be executed from the root of the repository.